### PR TITLE
Default return value for `schema_wp_breadcrumb_woo_product_disable`

### DIFF
--- a/includes/integrations/woocommerce.php
+++ b/includes/integrations/woocommerce.php
@@ -23,4 +23,5 @@ function schema_wp_breadcrumb_woo_product_disable( $breadcrumb_enabled ){
 	if ( class_exists( 'woocommerce' ) ) { 
 		if ( is_woocommerce() ) return false;
 	}
+	return true;
 }


### PR DESCRIPTION
Return `true` if `woocommerce` does not exist.
Otherwise the filter `schema_wp_breadcrumb_enabled` will be `null` and the breadcrumb will not work forever.