### PR TITLE
Add organization and author ids so google can identify multiple

### DIFF
--- a/includes/json/author.php
+++ b/includes/json/author.php
@@ -72,7 +72,10 @@ function schema_wp_get_author_json( $type ) {
 	
 	if ( !empty($name) ) $schema['name'] = $name;
 	//if ( !empty($email) ) $schema['email'] = $email;
-	if ( !empty($url) ) $schema['url'] = $url;
+	if ( !empty($url) )  {
+	    $schema['url'] = $url;
+	    $schema['@id'] = $url;
+    }
 	if ( !empty($desc) ) $schema['description'] = $desc;
 	
 	return $schema;

--- a/includes/json/knowledge-graph.php
+++ b/includes/json/knowledge-graph.php
@@ -53,7 +53,7 @@ function schema_wp_output_knowledge_graph() {
 
 
 /**
- * The main function responsible for putting shema array all together
+ * The main function responsible for putting schema array all together
  *
  * @param string $type for schema type (example: Organization)
  * @since 1.0

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -104,6 +104,7 @@ function schema_wp_get_publisher_array() {
 	
 	$publisher = array(
 		"@type"	=> "Organization",	// default required value
+		"@id" => get_bloginfo("url") . "/#organization",
 		"name"	=> $name,
 		"logo"	=> array(
     		"@type" => "ImageObject",
@@ -112,7 +113,7 @@ function schema_wp_get_publisher_array() {
 			"height" => 60
 		)
 	);
-	
+
 	return apply_filters( 'schema_wp_publisher', $publisher );
 }
 


### PR DESCRIPTION
Would you be able to add this. Google seems to detect multiple instances of the same entity using the id better than using url. This is useful on archive pages where you have multiple references to the same publisher or author. 