### PR TITLE
Initialise JSON variable in amp.php

### DIFF
--- a/includes/integrations/amp.php
+++ b/includes/integrations/amp.php
@@ -20,6 +20,7 @@ function schema_wp_amp_modify_json_output( $metadata, $post ) {
 	
 	$about_page_id 		= schema_wp_get_option( 'about_page' );
 	$contact_page_id 	= schema_wp_get_option( 'contact_page' );
+	$json 			= null;
 	
 	if ( isset($about_page_id) && $post->ID == $about_page_id ) {
 		


### PR DESCRIPTION
Recent bug fixes has resulted in line 34 of amp.php `if ( $json )` returning an `undefined` error. 