### PR TITLE
Fix bogus markup for WooCommerce Category pages

### DIFF
--- a/includes/json/taxonomy.php
+++ b/includes/json/taxonomy.php
@@ -63,7 +63,7 @@ function schema_wp_get_taxonomy_json() {
     		
 			$schema_json = get_post_meta( $post->ID, '_schema_json', true );
 			
-			if ( isset($schema_json) ) {
+			if ( isset($schema_json) && ! is_empty($schema_json) ) {
 				$json[] = $schema_json;
 			}
 			


### PR DESCRIPTION
As per bug submitted at https://wordpress.org/support/topic/woocommerce-compatibility-50/ the markup injected on WooCommerce category pages is bogus/empty.  Added is_empty() check before adding output to avoid the bogus ld+json tag.