### PR TITLE
Fix for PHP 7.3

### DIFF
--- a/includes/admin/meta/class-meta.php
+++ b/includes/admin/meta/class-meta.php
@@ -77,7 +77,7 @@ function schema_wp_custom_meta_box_field( $field, $meta = null, $repeatable = nu
 		case 'tel':
 		case 'email':
 		default:
-			if ( is_array($meta) ) continue; // if $meta has an array, continue to the next case, @since 1.6.9.4 
+			if ( is_array($meta) ) break; // if $meta has an array, continue to the next case, @since 1.6.9.4 
 			echo '<input type="' . $type . '" name="' . esc_attr( $name ) . '" id="' . esc_attr( $id ) . '" value="' . esc_attr( $meta ) . '" class="'.$size.'-text '.$class.'" size="30" placeholder="' . $placeholder . '" />
 					<br />' . $desc;
 		break;


### PR DESCRIPTION
Hi,

Just tried this on my site and it is broken due to this deprecated feature in PHP 7.3. Should be a quick fix because continue is the same as break in a switch in PHP. 

Regarding the code I'm not sure of the intent though - if I try to hit a default case and continue to another case - the default is skipped anyway:

https://3v4l.org/X8aue  - so I'm not sure this default case ever gets hit if there is a matching case below.

Thanks!